### PR TITLE
Add DC on macOS schema support for and, or, and not

### DIFF
--- a/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
+++ b/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
@@ -297,6 +297,12 @@
             }]
         },
         "query": {
+            "oneOf": [
+                { "$ref": "#/$defs/binaryQuery" },
+                { "$ref": "#/$defs/unaryQuery" }
+            ]
+        },
+        "binaryQuery": {
             "type": "object",
             "title": "A query which describes the devices to include in this group",
             "required": [
@@ -316,7 +322,7 @@
             ],
             "properties": {
                 "$type": {
-                    "enum": [ "any", "all" ],
+                    "enum": [ "any", "or", "all", "and" ],
                     "title": "Describes how this query combines clauses and subqueries",
                     "examples": [
                         "all",
@@ -410,6 +416,38 @@
                     "$type": "serialNumber",
                     "value": "ABCDEFGHIJKLMNOP"
                 }]
+            }]
+        },
+        "unaryQuery": {
+            "type": "object",
+            "title": "A query which describes the devices to include in this group",
+            "required": [
+                "$type",
+                "query"
+            ],
+            "properties": {
+                "$type": {
+                    "enum": [ "not" ],
+                    "title": "Describes how this query combines clauses and subqueries",
+                    "examples": [
+                        "not"
+                    ]
+                },
+                "query": { "$ref": "#/$defs/query" }
+            },
+            "examples": [{
+                "$type": "not",
+                "query": {
+                    "$type": "and",
+                    "clauses": [{
+                        "$type": "primaryId",
+                        "value": "apple_devices"
+                    },
+                    {
+                        "$type": "primaryId",
+                        "value": "other_devices"
+                    }]
+                }
             }]
         },
         "denyEnforcement": {


### PR DESCRIPTION
Update the device_control_policy_schema.json to include support for a negation operator, as well as aliases to existing operators that better match boolean logic. 

|Query Type|description|notes|
|--------|------------|-----|
|and|A device will be included in the group if all clauses and subqueries match|Alias for the existing 'all' operator|
|or|A device will be included in the group if any of the clauses or subqueries match|Alias for the existing 'any' operator|
|not|A device will be included in the group if it is not matched by the subquery|New|