### PR TITLE
MacOS: Add support for bluetooth devices

### DIFF
--- a/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
+++ b/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
@@ -125,6 +125,7 @@
                             "oneOf": [
                                 { "$ref": "#/$defs/appleDeviceEntry" },
                                 { "$ref": "#/$defs/removableMediaEntry" },
+                                { "$ref": "#/$defs/bluetoothDeviceEntry" },
                                 { "$ref": "#/$defs/genericEntry" }
                             ]
                         }
@@ -172,6 +173,22 @@
                                     "title": "Disable the Removable Media feature?",
                                     "examples": [
                                         false
+                                    ]
+                                }
+                            }
+                        },
+                        "bluetoothDevice": {
+                            "type": "object",
+                            "default": {},
+                            "title": "Setting for Bluetooth Devices",
+                            "additionalProperties": false,
+                            "properties": {
+                                "disable": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "title": "Disable the Bluetooth Devices feature?",
+                                    "examples": [
+                                        true
                                     ]
                                 }
                             }
@@ -242,7 +259,7 @@
                     "enum": [ "primaryId" ]
                 },
                 "value": {
-                    "enum": [ "apple_devices", "removable_media_devices" ],
+                    "enum": [ "apple_devices", "removable_media_devices", "bluetooth_devices" ],
                     "title": "The device family"
                 }
             },
@@ -646,6 +663,36 @@
                 }
             }
         },
+        "bluetoothDeviceEntry": {
+            "title": "An entry for a bluetooth device",
+            "required": [
+                "$type",
+                "enforcement",
+                "access"
+            ],
+            "properties": {
+                "$type": {
+                    "enum": [ "bluetoothDevice" ]
+                },
+                "enforcement": { "$ref": "#/$defs/enforcement" },
+                "access": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "title": "The access kind to control",
+                    "items": {
+                        "enum": [
+                            "download_files_from_device",
+                            "send_files_to_device"
+                        ],
+                        "title": "Bluetooth Device specific access types",
+                        "esamples": [
+                            "send_files_to_device"
+                        ]
+                    }
+                }
+            }
+        },
         "genericEntry": {
             "title": "An entry to generically control actions",
             "required": [
@@ -833,6 +880,9 @@
                 },
                 "removableMedia": {
                     "disable": null
+                },
+                "bluetoothDevice": {
+                    "disable": false
                 }
             },
             "global": {


### PR DESCRIPTION
Updates the macOS device control schema to include bluetooth device support.