### PR TITLE
[macOS] Add groupId clause to DC policy group query

### DIFF
--- a/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
+++ b/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
@@ -42,21 +42,25 @@
                             "Dev Devices"
                         ]
                     },
-                    "query": { 
-                        "$ref": "#/$defs/query" 
+                    "query": {
+                        "$ref": "#/$defs/query"
                     }
                 },
-                "examples": [{
-                    "id": "3f082cd3-f701-4c21-9a6a-ed115c28e217",
-                    "name": "All Apple Devices",
-                    "query": {
-                        "$type": "all",
-                        "clauses": [{
-                            "$type": "primaryId",
-                            "value": "apple_devices"
-                        }]
+                "examples": [
+                    {
+                        "id": "3f082cd3-f701-4c21-9a6a-ed115c28e217",
+                        "name": "All Apple Devices",
+                        "query": {
+                            "$type": "all",
+                            "clauses": [
+                                {
+                                    "$type": "primaryId",
+                                    "value": "apple_devices"
+                                }
+                            ]
+                        }
                     }
-                }]
+                ]
             }
         },
         "rules": {
@@ -127,10 +131,18 @@
                             "type": "object",
                             "title": "A rule entry",
                             "oneOf": [
-                                { "$ref": "#/$defs/appleDeviceEntry" },
-                                { "$ref": "#/$defs/removableMediaEntry" },
-                                { "$ref": "#/$defs/bluetoothDeviceEntry" },
-                                { "$ref": "#/$defs/genericEntry" }
+                                {
+                                    "$ref": "#/$defs/appleDeviceEntry"
+                                },
+                                {
+                                    "$ref": "#/$defs/removableMediaEntry"
+                                },
+                                {
+                                    "$ref": "#/$defs/bluetoothDeviceEntry"
+                                },
+                                {
+                                    "$ref": "#/$defs/genericEntry"
+                                }
                             ]
                         }
                     }
@@ -198,11 +210,13 @@
                             }
                         }
                     },
-                    "examples": [{
-                        "appleDevice": {
-                            "disable": false
+                    "examples": [
+                        {
+                            "appleDevice": {
+                                "disable": false
+                            }
                         }
-                    }]
+                    ]
                 },
                 "global": {
                     "type": "object",
@@ -211,7 +225,10 @@
                     "additionalProperties": false,
                     "properties": {
                         "defaultEnforcement": {
-                            "enum": [ "allow", "deny" ],
+                            "enum": [
+                                "allow",
+                                "deny"
+                            ],
                             "default": "allow",
                             "title": "Default Enforcement if no rules match an action.",
                             "examples": [
@@ -236,24 +253,27 @@
                     }
                 }
             },
-            "examples": [{
-                "features": {
-                    "appleDevice": {
-                        "disable": false
+            "examples": [
+                {
+                    "features": {
+                        "appleDevice": {
+                            "disable": false
+                        }
+                    },
+                    "global": {
+                        "defaultEnforcement": "deny"
+                    },
+                    "ux": {
+                        "navigationTarget": "http://www.microsoft.com"
                     }
-                },
-                "global": {
-                    "defaultEnforcement": "deny"
-                },
-                "ux": {
-                    "navigationTarget": "http://www.microsoft.com"
                 }
-            }]
+            ]
         }
     },
     "$defs": {
         "primaryIdClause": {
-            "title": "Query to match a device to an overall device family",
+            "title": "Primary ID Clause",
+            "description": "Match a device to an overall device family",
             "required": [
                 "$type",
                 "value"
@@ -261,20 +281,29 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "primaryId" ]
+                    "enum": [
+                        "primaryId"
+                    ]
                 },
                 "value": {
-                    "enum": [ "apple_devices", "removable_media_devices", "bluetooth_devices" ],
+                    "enum": [
+                        "apple_devices",
+                        "removable_media_devices",
+                        "bluetooth_devices"
+                    ],
                     "title": "The device family"
                 }
             },
-            "examples": [{
-                "$type": "primaryId",
-                "value": "apple_devices"
-            }]
+            "examples": [
+                {
+                    "$type": "primaryId",
+                    "value": "apple_devices"
+                }
+            ]
         },
         "vendorIdClause": {
-            "title": "Query to match a device with a specific vendor ID",
+            "title": "Vendor ID Clause",
+            "description": "Match a device with a specific vendor ID",
             "required": [
                 "$type",
                 "value"
@@ -282,7 +311,9 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "vendorId" ]
+                    "enum": [
+                        "vendorId"
+                    ]
                 },
                 "value": {
                     "type": "string",
@@ -290,13 +321,16 @@
                     "title": "4 digit vendor ID in hexadecimal"
                 }
             },
-            "examples": [{
-                "$type": "vendorId",
-                "value": "1234"
-            }]
+            "examples": [
+                {
+                    "$type": "vendorId",
+                    "value": "1234"
+                }
+            ]
         },
         "productIdClause": {
-            "title": "Query to match a device with a specific product ID",
+            "title": "Product ID Clause",
+            "description": "Match a device with a specific product ID",
             "required": [
                 "$type",
                 "value"
@@ -304,7 +338,9 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "productId" ]
+                    "enum": [
+                        "productId"
+                    ]
                 },
                 "value": {
                     "type": "string",
@@ -312,13 +348,16 @@
                     "title": "4 digit product ID in hexadecimal"
                 }
             },
-            "examples": [{
-                "$type": "productId",
-                "value": "12AB"
-            }]
+            "examples": [
+                {
+                    "$type": "productId",
+                    "value": "12AB"
+                }
+            ]
         },
         "serialNumberClause": {
-            "title": "Query to match a device with a specific serial number",
+            "title": "Serial Number Clause",
+            "description": "Match a device with a specific serial number",
             "required": [
                 "$type",
                 "value"
@@ -326,22 +365,62 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "serialNumber" ]
+                    "enum": [
+                        "serialNumber"
+                    ]
                 },
                 "value": {
                     "type": "string",
                     "title": "Serial Number"
                 }
             },
-            "examples": [{
-                "$type": "serialNumber",
-                "value": "ABCDEFGHIJKLMNOP"
-            }]
+            "examples": [
+                {
+                    "$type": "serialNumber",
+                    "value": "ABCDEFGHIJKLMNOP"
+                }
+            ]
+        },
+        "groupIdClause": {
+            "title": "Group ID Clause",
+            "description": "Match if a device is a member of a different group.  Note: ID must belong to a group that was defined prior to this clause.",
+            "required": [
+                "$type",
+                "value"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "$type": {
+                    "enum": [
+                        "groupId"
+                    ]
+                },
+                "value": {
+                    "type": "string",
+                    "title": "Group ID",
+                    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                    "examples": [
+                        "3f082cd3-f701-4c21-9a6a-ed115c28e217",
+                        "34aec8e5-e2fa-4d1e-8788-2b1284226653",
+                        "03f025f6-ee9d-49b2-b192-fc7a00df6856"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "$type": "groupId",
+                    "value": "3f082cd3-f701-4c21-9a6a-ed115c28e217"
+                }
+            ]
         },
         "query": {
             "oneOf": [
-                { "$ref": "#/$defs/binaryQuery" },
-                { "$ref": "#/$defs/unaryQuery" }
+                {
+                    "$ref": "#/$defs/binaryQuery"
+                },
+                {
+                    "$ref": "#/$defs/unaryQuery"
+                }
             ]
         },
         "binaryQuery": {
@@ -365,7 +444,12 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "any", "or", "all", "and" ],
+                    "enum": [
+                        "any",
+                        "or",
+                        "all",
+                        "and"
+                    ],
                     "title": "Describes how this query combines clauses and subqueries",
                     "examples": [
                         "all",
@@ -380,10 +464,21 @@
                         "type": "object",
                         "title": "An individual clause to match against a device",
                         "oneOf": [
-                            { "$ref": "#/$defs/primaryIdClause" },
-                            { "$ref": "#/$defs/vendorIdClause" },
-                            { "$ref": "#/$defs/productIdClause" },
-                            { "$ref": "#/$defs/serialNumberClause" }
+                            {
+                                "$ref": "#/$defs/primaryIdClause"
+                            },
+                            {
+                                "$ref": "#/$defs/vendorIdClause"
+                            },
+                            {
+                                "$ref": "#/$defs/productIdClause"
+                            },
+                            {
+                                "$ref": "#/$defs/serialNumberClause"
+                            },
+                            {
+                                "$ref": "#/$defs/groupIdClause"
+                            }
                         ]
                     }
                 },
@@ -391,75 +486,95 @@
                     "type": "array",
                     "minItems": 1,
                     "title": "Subqueries to evaluate",
-                    "items": { "$ref": "#/$defs/query" }
+                    "items": {
+                        "$ref": "#/$defs/query"
+                    }
                 }
             },
-            "examples": [{
-                "$type": "all",
-                "clauses": [{
-                    "$type": "primaryId",
-                    "value": "apple_devices"
-                }]
-            },
-            {
-                "$type": "any",
-                "clauses": [{
-                    "$type": "vendorId",
-                    "value": "1234"
-                },
+            "examples": [
                 {
-                    "$type": "productId",
-                    "value": "4321"
-                },
-                {
-                    "$type": "serialNumber",
-                    "value": "ABCDEFGHIJKLMNOP"
-                }],
-                "subqueries": [{
                     "$type": "all",
-                    "clauses": [{
-                        "$type": "vendorId",
-                        "value": "4321"
-                    },
-                    {
-                        "$type": "productId",
-                        "value": "1234"
-                    }]
+                    "clauses": [
+                        {
+                            "$type": "primaryId",
+                            "value": "apple_devices"
+                        }
+                    ]
                 },
                 {
                     "$type": "any",
-                    "clauses": [{
-                        "$type": "vendorId",
-                        "value": "2222"
-                    },
-                    {
-                        "$type": "productId",
-                        "value": "3333"
-                    }],
-                    "subqueries": [{
-                        "$type": "all",
-                        "clauses": [{
+                    "clauses": [
+                        {
                             "$type": "vendorId",
-                            "value": "4444"
-                        }]
-                    }]
-                }]
-            },
-            {
-                "$type": "any",
-                "clauses": [{
-                    "$type": "vendorId",
-                    "value": "12345"
+                            "value": "1234"
+                        },
+                        {
+                            "$type": "productId",
+                            "value": "4321"
+                        },
+                        {
+                            "$type": "serialNumber",
+                            "value": "ABCDEFGHIJKLMNOP"
+                        }
+                    ],
+                    "subqueries": [
+                        {
+                            "$type": "all",
+                            "clauses": [
+                                {
+                                    "$type": "vendorId",
+                                    "value": "4321"
+                                },
+                                {
+                                    "$type": "productId",
+                                    "value": "1234"
+                                }
+                            ]
+                        },
+                        {
+                            "$type": "any",
+                            "clauses": [
+                                {
+                                    "$type": "vendorId",
+                                    "value": "2222"
+                                },
+                                {
+                                    "$type": "productId",
+                                    "value": "3333"
+                                }
+                            ],
+                            "subqueries": [
+                                {
+                                    "$type": "all",
+                                    "clauses": [
+                                        {
+                                            "$type": "vendorId",
+                                            "value": "4444"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
                 },
                 {
-                    "$type": "productId",
-                    "value": "AZ"
-                },
-                {
-                    "$type": "serialNumber",
-                    "value": "ABCDEFGHIJKLMNOP"
-                }]
-            }]
+                    "$type": "any",
+                    "clauses": [
+                        {
+                            "$type": "vendorId",
+                            "value": "12345"
+                        },
+                        {
+                            "$type": "productId",
+                            "value": "AZ"
+                        },
+                        {
+                            "$type": "serialNumber",
+                            "value": "ABCDEFGHIJKLMNOP"
+                        }
+                    ]
+                }
+            ]
         },
         "unaryQuery": {
             "type": "object",
@@ -471,30 +586,36 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "not" ],
+                    "enum": [
+                        "not"
+                    ],
                     "title": "Describes how this query combines clauses and subqueries",
                     "examples": [
                         "not"
                     ]
                 },
-                "query": { 
+                "query": {
                     "$ref": "#/$defs/query"
                 }
             },
-            "examples": [{
-                "$type": "not",
-                "query": {
-                    "$type": "and",
-                    "clauses": [{
-                        "$type": "primaryId",
-                        "value": "apple_devices"
-                    },
-                    {
-                        "$type": "primaryId",
-                        "value": "other_devices"
-                    }]
+            "examples": [
+                {
+                    "$type": "not",
+                    "query": {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "primaryId",
+                                "value": "apple_devices"
+                            },
+                            {
+                                "$type": "primaryId",
+                                "value": "other_devices"
+                            }
+                        ]
+                    }
                 }
-            }]
+            ]
         },
         "denyEnforcement": {
             "title": "Access should be denied",
@@ -504,7 +625,9 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "deny" ]
+                    "enum": [
+                        "deny"
+                    ]
                 },
                 "options": {
                     "type": "array",
@@ -530,7 +653,9 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "allow" ]
+                    "enum": [
+                        "allow"
+                    ]
                 },
                 "options": {
                     "type": "array",
@@ -558,7 +683,9 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "auditDeny" ]
+                    "enum": [
+                        "auditDeny"
+                    ]
                 },
                 "options": {
                     "type": "array",
@@ -583,7 +710,9 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "auditAllow" ]
+                    "enum": [
+                        "auditAllow"
+                    ]
                 },
                 "options": {
                     "type": "array",
@@ -600,10 +729,18 @@
         },
         "enforcement": {
             "oneOf": [
-                { "$ref": "#/$defs/denyEnforcement" },
-                { "$ref": "#/$defs/allowEnforcement" },
-                { "$ref": "#/$defs/auditDenyEnforcement" },
-                { "$ref": "#/$defs/auditAllowEnforcement" }
+                {
+                    "$ref": "#/$defs/denyEnforcement"
+                },
+                {
+                    "$ref": "#/$defs/allowEnforcement"
+                },
+                {
+                    "$ref": "#/$defs/auditDenyEnforcement"
+                },
+                {
+                    "$ref": "#/$defs/auditAllowEnforcement"
+                }
             ]
         },
         "appleDeviceEntry": {
@@ -616,9 +753,13 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "appleDevice" ]
+                    "enum": [
+                        "appleDevice"
+                    ]
                 },
-                "enforcement": { "$ref": "#/$defs/enforcement" },
+                "enforcement": {
+                    "$ref": "#/$defs/enforcement"
+                },
                 "access": {
                     "type": "array",
                     "minItems": 1,
@@ -639,23 +780,25 @@
                     }
                 }
             },
-            "examples": [{
-                "$type": "appleDevice",
-                "enforcement": {
-                    "$type": "allow",
-                    "options": [
-                        "disable_audit_deny",
-                        "disable_audit_allow"
+            "examples": [
+                {
+                    "$type": "appleDevice",
+                    "enforcement": {
+                        "$type": "allow",
+                        "options": [
+                            "disable_audit_deny",
+                            "disable_audit_allow"
+                        ]
+                    },
+                    "access": [
+                        "download_files_from_device",
+                        "sync_content_to_device",
+                        "backup_device",
+                        "update_device",
+                        "download_photos_from_device"
                     ]
-                },
-                "access": [
-                    "download_files_from_device",
-                    "sync_content_to_device",
-                    "backup_device",
-                    "update_device",
-                    "download_photos_from_device"
-                ]
-            }]
+                }
+            ]
         },
         "removableMediaEntry": {
             "title": "An entry for a removable media device",
@@ -667,9 +810,13 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "removableMedia" ]
+                    "enum": [
+                        "removableMedia"
+                    ]
                 },
-                "enforcement": { "$ref": "#/$defs/enforcement" },
+                "enforcement": {
+                    "$ref": "#/$defs/enforcement"
+                },
                 "access": {
                     "type": "array",
                     "minItems": 1,
@@ -699,9 +846,13 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "bluetoothDevice" ]
+                    "enum": [
+                        "bluetoothDevice"
+                    ]
                 },
-                "enforcement": { "$ref": "#/$defs/enforcement" },
+                "enforcement": {
+                    "$ref": "#/$defs/enforcement"
+                },
                 "access": {
                     "type": "array",
                     "minItems": 1,
@@ -730,9 +881,13 @@
             "additionalProperties": false,
             "properties": {
                 "$type": {
-                    "enum": [ "generic" ]
+                    "enum": [
+                        "generic"
+                    ]
                 },
-                "enforcement": { "$ref": "#/$defs/enforcement" },
+                "enforcement": {
+                    "$ref": "#/$defs/enforcement"
+                },
                 "access": {
                     "type": "array",
                     "minItems": 1,
@@ -751,174 +906,202 @@
                     }
                 }
             },
-            "examples": [{
-                "$type": "generic",
-                "enforcement": {
-                    "$type": "deny"
-                },
-                "access": [
-                    "generic_read",
-                    "generic_write",
-                    "generic_execute"
-                ]
-            }]
+            "examples": [
+                {
+                    "$type": "generic",
+                    "enforcement": {
+                        "$type": "deny"
+                    },
+                    "access": [
+                        "generic_read",
+                        "generic_write",
+                        "generic_execute"
+                    ]
+                }
+            ]
         }
     },
-    "examples": [{
-        "groups": [{
-            "id": "3f082cd3-f701-4c21-9a6a-ed115c28e217",
-            "name": "All Apple Devices",
-            "query": {
-                "$type": "all",
-                "clauses": [{
-                    "$type": "primaryId",
-                    "value": "apple_devices"
-                }]
-            }
-        },
+    "examples": [
         {
-            "id": "34aec8e5-e2fa-4d1e-8788-2b1284226653",
-            "query": {
-                "$type": "any",
-                "clauses": [{
-                    "$type": "vendorId",
-                    "value": "1234"
-                },
+            "groups": [
                 {
-                    "$type": "productId",
-                    "value": "4321"
-                },
-                {
-                    "$type": "serialNumber",
-                    "value": "ABCDEFGHIJKLMNOP"
-                }],
-                "subqueries": [{
-                    "$type": "all",
-                    "clauses": [{
-                        "$type": "vendorId",
-                        "value": "4321"
-                    },
-                    {
-                        "$type": "productId",
-                        "value": "1234"
-                    }]
-                },
-                {
-                    "$type": "any",
-                    "clauses": [{
-                        "$type": "vendorId",
-                        "value": "2222"
-                    },
-                    {
-                        "$type": "productId",
-                        "value": "3333"
-                    }],
-                    "subqueries": [{
+                    "id": "3f082cd3-f701-4c21-9a6a-ed115c28e217",
+                    "name": "All Apple Devices",
+                    "query": {
                         "$type": "all",
-                        "clauses": [{
-                            "$type": "vendorId",
-                            "value": "4444"
-                        }]
-                    }]
-                }]
-            }
-        },
-        {
-            "id": "03f025f6-ee9d-49b2-b192-fc7a00df6856",
-            "name": "Dev Machines",
-            "query": {
-                "$type": "any",
-                "clauses": [{
-                    "$type": "vendorId",
-                    "value": "12345"
+                        "clauses": [
+                            {
+                                "$type": "primaryId",
+                                "value": "apple_devices"
+                            }
+                        ]
+                    }
                 },
                 {
-                    "$type": "productId",
-                    "value": "AZ"
+                    "id": "34aec8e5-e2fa-4d1e-8788-2b1284226653",
+                    "query": {
+                        "$type": "any",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "1234"
+                            },
+                            {
+                                "$type": "productId",
+                                "value": "4321"
+                            },
+                            {
+                                "$type": "serialNumber",
+                                "value": "ABCDEFGHIJKLMNOP"
+                            }
+                        ],
+                        "subqueries": [
+                            {
+                                "$type": "all",
+                                "clauses": [
+                                    {
+                                        "$type": "vendorId",
+                                        "value": "4321"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "1234"
+                                    }
+                                ]
+                            },
+                            {
+                                "$type": "any",
+                                "clauses": [
+                                    {
+                                        "$type": "vendorId",
+                                        "value": "2222"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "3333"
+                                    }
+                                ],
+                                "subqueries": [
+                                    {
+                                        "$type": "all",
+                                        "clauses": [
+                                            {
+                                                "$type": "vendorId",
+                                                "value": "4444"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
                 },
                 {
-                    "$type": "serialNumber",
-                    "value": "ABCDEFGHIJKLMNOP"
-                }]
-            }
-        }],
-        "rules": [{
-            "id": "772cef80-229f-48b4-bd17-a6913009298d",
-            "name": "Test Rule #1",
-            "includeGroups": [
-                "3f082cd3-f701-4c21-9a6a-ed115c28e217"
+                    "id": "03f025f6-ee9d-49b2-b192-fc7a00df6856",
+                    "name": "Dev Machines",
+                    "query": {
+                        "$type": "any",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "12345"
+                            },
+                            {
+                                "$type": "productId",
+                                "value": "AZ"
+                            },
+                            {
+                                "$type": "serialNumber",
+                                "value": "ABCDEFGHIJKLMNOP"
+                            }
+                        ]
+                    }
+                }
             ],
-            "excludeGroups": [
-                "34aec8e5-e2fa-4d1e-8788-2b1284226653"
-            ],
-            "entries": [{
-                "$type": "appleDevice",
-                "enforcement": {
-                    "$type": "allow",
-                    "options": [
-                        "disable_audit_deny",
-                        "disable_audit_allow"
+            "rules": [
+                {
+                    "id": "772cef80-229f-48b4-bd17-a6913009298d",
+                    "name": "Test Rule #1",
+                    "includeGroups": [
+                        "3f082cd3-f701-4c21-9a6a-ed115c28e217"
+                    ],
+                    "excludeGroups": [
+                        "34aec8e5-e2fa-4d1e-8788-2b1284226653"
+                    ],
+                    "entries": [
+                        {
+                            "$type": "appleDevice",
+                            "enforcement": {
+                                "$type": "allow",
+                                "options": [
+                                    "disable_audit_deny",
+                                    "disable_audit_allow"
+                                ]
+                            },
+                            "access": [
+                                "download_files_from_device",
+                                "sync_content_to_device",
+                                "backup_device",
+                                "update_device",
+                                "download_photos_from_device"
+                            ]
+                        },
+                        {
+                            "$type": "generic",
+                            "enforcement": {
+                                "$type": "deny"
+                            },
+                            "access": [
+                                "generic_read",
+                                "generic_write",
+                                "generic_execute"
+                            ]
+                        }
                     ]
                 },
-                "access": [
-                    "download_files_from_device",
-                    "sync_content_to_device",
-                    "backup_device",
-                    "update_device",
-                    "download_photos_from_device"
-                ]
-            },
-            {
-                "$type": "generic",
-                "enforcement": {
-                    "$type": "deny"
-                },
-                "access": [
-                    "generic_read",
-                    "generic_write",
-                    "generic_execute"
-                ]
-            }]
-        },
-        {
-            "id": "bfabe24b-37a6-4bc0-9778-421aeaeece23",
-            "name": "Test Rule #2",
-            "includeGroups": [
-                "03f025f6-ee9d-49b2-b192-fc7a00df6856",
-                "03f025f6-ee9d-49b2-b192-fc7a00df6857",
-                "3f082cd3-f701-4c21-9a6a-ed115c28e217"
-            ],
-            "entries": [{
-                "$type": "appleDevice",
-                "enforcement": {
-                    "$type": "allow"
-                },
-                "access": [
-                    "update_device"
-                ]
-            }]
-        }],
-        "settings": {
-            "features": {
-                "appleDevice": {
-                    "disable": false
-                },
-                "portableDevice": {
-                    "disable": true
-                },
-                "removableMedia": {
-                    "disable": null
-                },
-                "bluetoothDevice": {
-                    "disable": false
+                {
+                    "id": "bfabe24b-37a6-4bc0-9778-421aeaeece23",
+                    "name": "Test Rule #2",
+                    "includeGroups": [
+                        "03f025f6-ee9d-49b2-b192-fc7a00df6856",
+                        "03f025f6-ee9d-49b2-b192-fc7a00df6857",
+                        "3f082cd3-f701-4c21-9a6a-ed115c28e217"
+                    ],
+                    "entries": [
+                        {
+                            "$type": "appleDevice",
+                            "enforcement": {
+                                "$type": "allow"
+                            },
+                            "access": [
+                                "update_device"
+                            ]
+                        }
+                    ]
                 }
-            },
-            "global": {
-                "defaultEnforcement": "deny"
-            },
-            "ux": {
-                "navigationTarget": "http://www.microsoft.com"
+            ],
+            "settings": {
+                "features": {
+                    "appleDevice": {
+                        "disable": false
+                    },
+                    "portableDevice": {
+                        "disable": true
+                    },
+                    "removableMedia": {
+                        "disable": null
+                    },
+                    "bluetoothDevice": {
+                        "disable": false
+                    }
+                },
+                "global": {
+                    "defaultEnforcement": "deny"
+                },
+                "ux": {
+                    "navigationTarget": "http://www.microsoft.com"
+                }
             }
         }
-    }]
+    ]
 }


### PR DESCRIPTION
   Add support for group ID clauses within the group query.  A group ID clause will match if a device is a member of the group denoted by the ID.

Note: macOS Device Control evaluates groups in the order they are defined in the policy JSON.  Consequently, a group will not match unless it was defined prior to the group ID query clause.  This behavior diverges from the Windows Device Control implementation of group id, which is order agnostic.  The macOS implementation may be updated in the future to align with the Windows functionality - which will have no impact on policies created with the current ordering constraints.