### PR TITLE
[macOS] Remove subqueries field in favor of having such queries directly within the clauses

### DIFF
--- a/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
+++ b/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
@@ -433,25 +433,6 @@
                 }
             ]
         },
-        "queryClause": {
-            "title": "Query Clause",
-            "description": "Match if a subquery matches",
-            "required": [
-                "$type",
-                "value"
-            ],
-            "additionalProperties": false,
-            "properties": {
-                "$type": {
-                    "enum": [
-                        "query"
-                    ]
-                },
-                "value": {
-                    "$ref": "#/$defs/query"
-                }
-            }
-        },
         "query": {
             "oneOf": [
                 {
@@ -519,7 +500,7 @@
                                 "$ref": "#/$defs/groupIdClause"
                             },
                             {
-                                "$ref": "#/$defs/queryClause"
+                                "$ref": "#/$defs/query"
                             }
                         ]
                     }

--- a/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
+++ b/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
@@ -433,6 +433,25 @@
                 }
             ]
         },
+        "queryClause": {
+            "title": "Query Clause",
+            "description": "Match if a subquery matches",
+            "required": [
+                "$type",
+                "value"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "$type": {
+                    "enum": [
+                        "query"
+                    ]
+                },
+                "value": {
+                    "$ref": "#/$defs/query"
+                }
+            }
+        },
         "query": {
             "oneOf": [
                 {
@@ -498,16 +517,11 @@
                             },
                             {
                                 "$ref": "#/$defs/groupIdClause"
+                            },
+                            {
+                                "$ref": "#/$defs/queryClause"
                             }
                         ]
-                    }
-                },
-                "subqueries": {
-                    "type": "array",
-                    "minItems": 1,
-                    "title": "Subqueries to evaluate",
-                    "items": {
-                        "$ref": "#/$defs/query"
                     }
                 }
             },


### PR DESCRIPTION
    The groupId clause was recently added to queries for parity with the Windows DC policy implementation.  Since groupId is an 'aggregate' clause, it makes sense to align subqueries with this approach.  Now subqueries, can be defined directly within clause statements.