### PR TITLE
[macOS] Add example policy JSON

### DIFF
--- a/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
+++ b/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
@@ -44,6 +44,9 @@
                     },
                     "query": {
                         "$ref": "#/$defs/query"
+                    },
+                    "__comments": {
+                        "type": "string"
                     }
                 },
                 "examples": [
@@ -73,7 +76,6 @@
                 "required": [
                     "id",
                     "name",
-                    "includeGroups",
                     "entries"
                 ],
                 "additionalProperties": false,
@@ -97,7 +99,7 @@
                     },
                     "includeGroups": {
                         "type": "array",
-                        "minItems": 1,
+                        "minItems": 0,
                         "title": "List of all the groups that a device must be a member of (logical AND) for this rule to be applicable.",
                         "items": {
                             "type": "string",
@@ -112,7 +114,7 @@
                     },
                     "excludeGroups": {
                         "type": "array",
-                        "minItems": 1,
+                        "minItems": 0,
                         "title": "List of groups which override the applicability logic of includeGroups.  Membership in any of these groups (logical OR) will disable the rule for a device.",
                         "items": {
                             "type": "string",
@@ -148,6 +150,9 @@
                                 }
                             ]
                         }
+                    },
+                    "__comments": {
+                        "type": "string"
                     }
                 }
             }
@@ -177,6 +182,9 @@
                                     "examples": [
                                         false
                                     ]
+                                },
+                                "__comments": {
+                                    "type": "string"
                                 }
                             }
                         },
@@ -193,6 +201,9 @@
                                     "examples": [
                                         false
                                     ]
+                                },
+                                "__comments": {
+                                    "type": "string"
                                 }
                             }
                         },
@@ -209,6 +220,9 @@
                                     "examples": [
                                         true
                                     ]
+                                },
+                                "__comments": {
+                                    "type": "string"
                                 }
                             }
                         },
@@ -225,8 +239,14 @@
                                     "examples": [
                                         true
                                     ]
+                                },
+                                "__comments": {
+                                    "type": "string"
                                 }
                             }
+                        },
+                        "__comments": {
+                            "type": "string"
                         }
                     },
                     "examples": [
@@ -253,6 +273,9 @@
                             "examples": [
                                 "deny"
                             ]
+                        },
+                        "__comments": {
+                            "type": "string"
                         }
                     }
                 },
@@ -268,8 +291,14 @@
                             "examples": [
                                 "http://www.microsoft.com"
                             ]
+                        },
+                        "__comments": {
+                            "type": "string"
                         }
                     }
+                },
+                "__comments": {
+                    "type": "string"
                 }
             },
             "examples": [
@@ -287,6 +316,9 @@
                     }
                 }
             ]
+        },
+        "__comments": {
+            "type": "string"
         }
     },
     "$defs": {
@@ -312,6 +344,9 @@
                         "portable_devices"
                     ],
                     "title": "The device family"
+                },
+                "__comments": {
+                    "type": "string"
                 }
             },
             "examples": [
@@ -339,6 +374,9 @@
                     "type": "string",
                     "pattern": "^[a-fA-F0-9]{4}$",
                     "title": "4 digit vendor ID in hexadecimal"
+                },
+                "__comments": {
+                    "type": "string"
                 }
             },
             "examples": [
@@ -366,6 +404,9 @@
                     "type": "string",
                     "pattern": "^[a-fA-F0-9]{4}$",
                     "title": "4 digit product ID in hexadecimal"
+                },
+                "__comments": {
+                    "type": "string"
                 }
             },
             "examples": [
@@ -392,6 +433,9 @@
                 "value": {
                     "type": "string",
                     "title": "Serial Number"
+                },
+                "__comments": {
+                    "type": "string"
                 }
             },
             "examples": [
@@ -424,6 +468,9 @@
                         "34aec8e5-e2fa-4d1e-8788-2b1284226653",
                         "03f025f6-ee9d-49b2-b192-fc7a00df6856"
                     ]
+                },
+                "__comments": {
+                    "type": "string"
                 }
             },
             "examples": [
@@ -504,6 +551,9 @@
                             }
                         ]
                     }
+                },
+                "__comments": {
+                    "type": "string"
                 }
             },
             "examples": [
@@ -611,6 +661,9 @@
                 },
                 "query": {
                     "$ref": "#/$defs/query"
+                },
+                "__comments": {
+                    "type": "string"
                 }
             },
             "examples": [
@@ -657,6 +710,9 @@
                 "tag": {
                     "type": "number",
                     "title": "Custom tag to propogate to portal"
+                },
+                "__comments": {
+                    "type": "string"
                 }
             }
         },
@@ -686,6 +742,9 @@
                 "tag": {
                     "type": "number",
                     "title": "Custom tag to propogate to portal"
+                },
+                "__comments": {
+                    "type": "string"
                 }
             }
         },
@@ -713,6 +772,9 @@
                             "show_notification"
                         ]
                     }
+                },
+                "__comments": {
+                    "type": "string"
                 }
             }
         },
@@ -739,6 +801,9 @@
                             "send_event"
                         ]
                     }
+                },
+                "__comments": {
+                    "type": "string"
                 }
             }
         },
@@ -793,6 +858,9 @@
                             "download_files_from_device"
                         ]
                     }
+                },
+                "__comments": {
+                    "type": "string"
                 }
             },
             "examples": [
@@ -848,6 +916,9 @@
                             "read"
                         ]
                     }
+                },
+                "__comments": {
+                    "type": "string"
                 }
             }
         },
@@ -883,6 +954,9 @@
                             "send_files_to_device"
                         ]
                     }
+                },
+                "__comments": {
+                    "type": "string"
                 }
             }
         },
@@ -920,6 +994,9 @@
                             "send_files_to_device"
                         ]
                     }
+                },
+                "__comments": {
+                    "type": "string"
                 }
             }
         },
@@ -956,6 +1033,9 @@
                             "generic_read"
                         ]
                     }
+                },
+                "__comments": {
+                    "type": "string"
                 }
             },
             "examples": [

--- a/Removable Storage Access Control Samples/macOS/policy/examples/audit_all_apple_devices.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/audit_all_apple_devices.json
@@ -1,0 +1,57 @@
+{
+    "groups": [
+        {
+            "id": "3f082cd3-f701-4c21-9a6a-ed115c28e217",
+            "name": "All Apple Devices",
+            "query": {
+                "$type": "all",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "apple_devices"
+                    }
+                ]
+            }
+        }
+    ],
+    "rules": [
+        {
+            "id": "772cef80-229f-48b4-bd17-a6913009298e",
+            "name": "Audit all Apple Devices",
+            "includeGroups": [
+                "3f082cd3-f701-4c21-9a6a-ed115c28e217"
+            ],
+            "entries": [
+                {
+                    "$type": "appleDevice",
+                    "enforcement": {
+                        "$type": "auditAllow",
+                        "options": [
+                            "send_event"
+                        ]
+                    },
+                    "access": [
+                        "download_files_from_device",
+                        "sync_content_to_device",
+                        "backup_device",
+                        "update_device",
+                        "download_photos_from_device"
+                    ]
+                }
+            ]
+        }
+    ],
+    "settings": {
+        "features": {
+            "appleDevice": {
+                "disable": false
+            }
+        },
+        "global": {
+            "defaultEnforcement": "allow"
+        },
+        "ux": {
+            "navigationTarget": "http://www.microsoft.com"
+        }
+    }
+}

--- a/Removable Storage Access Control Samples/macOS/policy/examples/deny_all_bluetooth_devices_except_samsung.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/deny_all_bluetooth_devices_except_samsung.json
@@ -1,0 +1,111 @@
+{
+    "groups": [
+        {
+            "id": "3f082cd3-f701-4c21-9a6a-ed115c28e417",
+            "name": "All Bluetooth Devices",
+            "query": {
+                "$type": "or",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "bluetooth_devices"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "1A783D32-C6A3-4F5F-9D47-271B12130DFD",
+            "name": "Samsung Galaxy S21",
+            "query": {
+                "$type": "and",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "bluetooth_devices"
+                    },
+                    {
+                        "$type": "vendorId",
+                        "value": "0075"
+                    },
+                    {
+                        "$type": "productId",
+                        "value": "0100"
+                    }
+                ]
+            }
+        }
+    ],
+    "rules": [
+        {
+            "id": "772cef80-229f-48b4-bd17-a6913009248d",
+            "name": "Deny all Bluetooth Devices",
+            "includeGroups": [
+                "3f082cd3-f701-4c21-9a6a-ed115c28e417"
+            ],
+            "excludeGroups": [
+                "1A783D32-C6A3-4F5F-9D47-271B12130DFD"
+            ],
+            "entries": [
+                {
+                    "$type": "bluetoothDevice",
+                    "enforcement": {
+                        "$type": "deny"
+                    },
+                    "access": [
+                        "download_files_from_device",
+                        "send_files_to_device"
+                    ]
+                },
+                {
+                    "$type": "bluetoothDevice",
+                    "enforcement": {
+                        "$type": "auditDeny",
+                        "options": [
+                            "send_event",
+                            "show_notification"
+                        ]
+                    },
+                    "access": [
+                        "download_files_from_device",
+                        "send_files_to_device"
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "3C094B7B-DB94-4F17-86B8-3AA1D6547C58",
+            "name": "Audit S21",
+            "includeGroups": [
+                "1A783D32-C6A3-4F5F-9D47-271B12130DFD"
+            ],
+            "entries": [
+                {
+                    "$type": "bluetoothDevice",
+                    "enforcement": {
+                        "$type": "auditAllow",
+                        "options": [
+                            "send_event"
+                        ]
+                    },
+                    "access": [
+                        "download_files_from_device",
+                        "send_files_to_device"
+                    ]
+                }
+            ]
+        }
+    ],
+    "settings": {
+        "features": {
+            "bluetoothDevice": {
+                "disable": false
+            }
+        },
+        "global": {
+            "defaultEnforcement": "allow"
+        },
+        "ux": {
+            "navigationTarget": "http://www.microsoft.com"
+        }
+    }
+}

--- a/Removable Storage Access Control Samples/macOS/policy/examples/deny_debug_on_android.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/deny_debug_on_android.json
@@ -1,0 +1,76 @@
+{
+    "groups": [
+        {
+            "id": "3f082cd3-f701-4c21-9a6a-ed115c28e41D",
+            "name": "All Android Devices",
+            "query": {
+                "$type": "all",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "portable_devices"
+                    }
+                ]
+            }
+        }
+    ],
+    "rules": [
+        {
+            "id": "772cef80-229f-48b4-bd17-a6913009249d",
+            "name": "Deny all Portable Devices",
+            "includeGroups": [
+                "3f082cd3-f701-4c21-9a6a-ed115c28e41D"
+            ],
+            "entries": [
+                {
+                    "$type": "portableDevice",
+                    "enforcement": {
+                        "$type": "deny"
+                    },
+                    "access": [
+                        "debug"
+                    ]
+                },
+                {
+                    "$type": "portableDevice",
+                    "enforcement": {
+                        "$type": "auditDeny",
+                        "options": [
+                            "send_event",
+                            "show_notification"
+                        ]
+                    },
+                    "access": [
+                        "debug"
+                    ]
+                },
+                {
+                    "$type": "portableDevice",
+                    "enforcement": {
+                        "$type": "auditAllow",
+                        "options": [
+                            "send_event"
+                        ]
+                    },
+                    "access": [
+                        "download_files_from_device",
+                        "send_files_to_device"
+                    ]
+                }
+            ]
+        }
+    ],
+    "settings": {
+        "features": {
+            "portableDevice": {
+                "disable": false
+            }
+        },
+        "global": {
+            "defaultEnforcement": "allow"
+        },
+        "ux": {
+            "navigationTarget": "http://www.microsoft.com"
+        }
+    }
+}

--- a/Removable Storage Access Control Samples/macOS/policy/examples/deny_removable_media_except_kingston.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/deny_removable_media_except_kingston.json
@@ -1,0 +1,83 @@
+{
+    "groups": [
+        {
+            "id": "3f082cd3-f701-4c21-9a6a-ed115c28e211",
+            "name": "All Removable Media Devices",
+            "query": {
+                "$type": "all",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "removable_media_devices"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "3f082cd3-f701-4c21-9a6a-ed115c28e212",
+            "name": "Kingston Devices",
+            "query": {
+                "$type": "all",
+                "clauses": [
+                    {
+                        "$type": "vendorId",
+                        "value": "0951"
+                    }
+                ]
+            }
+        }
+    ],
+    "rules": [
+        {
+            "id": "772cef80-229f-48b4-bd17-a69130092981",
+            "name": "Deny RWX to all Removable Media Devices except Kingston",
+            "includeGroups": [
+                "3f082cd3-f701-4c21-9a6a-ed115c28e211"
+            ],
+            "excludeGroups": [
+                "3f082cd3-f701-4c21-9a6a-ed115c28e212"
+            ],
+            "entries": [
+                {
+                    "$type": "removableMedia",
+                    "enforcement": {
+                        "$type": "deny"
+                    },
+                    "access": [
+                        "read",
+                        "write",
+                        "execute"
+                    ]
+                },
+                {
+                    "$type": "removableMedia",
+                    "enforcement": {
+                        "$type": "auditDeny",
+                        "options": [
+                            "send_event",
+                            "show_notification"
+                        ]
+                    },
+                    "access": [
+                        "read",
+                        "write",
+                        "execute"
+                    ]
+                }
+            ]
+        }
+    ],
+    "settings": {
+        "features": {
+            "removableMedia": {
+                "disable": false
+            }
+        },
+        "global": {
+            "defaultEnforcement": "allow"
+        },
+        "ux": {
+            "navigationTarget": "http://www.microsoft.com"
+        }
+    }
+}

--- a/Removable Storage Access Control Samples/macOS/policy/examples/groups/any_removable_storage_and_portable_device_group.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/groups/any_removable_storage_and_portable_device_group.json
@@ -1,0 +1,21 @@
+{
+    "groups": [
+        {
+            "id": "9b28fae8-72f7-4267-a1a5-685f747a7146",
+            "name": "Any Removable Storage and Portable Device",
+            "query": {
+                "$type": "or",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "removable_media_devices"
+                    },
+                    {
+                        "$type": "primaryId",
+                        "value": "portable_devices"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Removable Storage Access Control Samples/macOS/policy/examples/groups/approved_usbs_group.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/groups/approved_usbs_group.json
@@ -4,24 +4,19 @@
             "id": "65fa649a-a111-4912-9294-fb6337a25038",
             "name": "Approved USBs",
             "query": {
-                "$type": "or",
+                "$type": "and",
                 "clauses": [
                     {
-                        "$type": "and",
-                        "clauses": [
-                            {
-                                "$type": "vendorId",
-                                "value": "0781"
-                            },
-                            {
-                                "$type": "productId",
-                                "value": "7102"
-                            },
-                            {
-                                "$type": "serialNumber",
-                                "value": "03003324080520232521"
-                            }
-                        ]
+                        "$type": "vendorId",
+                        "value": "0781"
+                    },
+                    {
+                        "$type": "productId",
+                        "value": "7102"
+                    },
+                    {
+                        "$type": "serialNumber",
+                        "value": "03003324080520232521"
                     }
                 ]
             }

--- a/Removable Storage Access Control Samples/macOS/policy/examples/groups/approved_usbs_group.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/groups/approved_usbs_group.json
@@ -1,0 +1,30 @@
+{
+    "groups": [
+        {
+            "id": "65fa649a-a111-4912-9294-fb6337a25038",
+            "name": "Approved USBs",
+            "query": {
+                "$type": "or",
+                "clauses": [
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "0781"
+                            },
+                            {
+                                "$type": "productId",
+                                "value": "7102"
+                            },
+                            {
+                                "$type": "serialNumber",
+                                "value": "03003324080520232521"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Removable Storage Access Control Samples/macOS/policy/examples/groups/demo_groups.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/groups/demo_groups.json
@@ -4,24 +4,19 @@
             "id": "65fa649a-a111-4912-9294-fb6337a25038",
             "name": "Approved USBs",
             "query": {
-                "$type": "or",
+                "$type": "and",
                 "clauses": [
                     {
-                        "$type": "and",
-                        "clauses": [
-                            {
-                                "$type": "vendorId",
-                                "value": "0781"
-                            },
-                            {
-                                "$type": "productId",
-                                "value": "7102"
-                            },
-                            {
-                                "$type": "serialNumber",
-                                "value": "03003324080520232521"
-                            }
-                        ]
+                        "$type": "vendorId",
+                        "value": "0781"
+                    },
+                    {
+                        "$type": "productId",
+                        "value": "7102"
+                    },
+                    {
+                        "$type": "serialNumber",
+                        "value": "03003324080520232521"
                     }
                 ]
             }

--- a/Removable Storage Access Control Samples/macOS/policy/examples/groups/demo_groups.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/groups/demo_groups.json
@@ -1,0 +1,47 @@
+{
+    "groups": [
+        {
+            "id": "65fa649a-a111-4912-9294-fb6337a25038",
+            "name": "Approved USBs",
+            "query": {
+                "$type": "or",
+                "clauses": [
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "0781"
+                            },
+                            {
+                                "$type": "productId",
+                                "value": "7102"
+                            },
+                            {
+                                "$type": "serialNumber",
+                                "value": "03003324080520232521"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "id": "9b28fae8-72f7-4267-a1a5-685f747a7146",
+            "name": "Any Removable Storage and Portable Device",
+            "query": {
+                "$type": "or",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "removable_media_devices"
+                    },
+                    {
+                        "$type": "primaryId",
+                        "value": "portable_devices"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Removable Storage Access Control Samples/macOS/policy/examples/groups/mass_storage_groups_gpo_2.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/groups/mass_storage_groups_gpo_2.json
@@ -1,0 +1,374 @@
+{
+    "groups": [
+        {
+            "id": "fb4ad01e-f41a-46c6-9ac1-268efa0ea083",
+            "name": "Group for all mass storage devices groups",
+            "query": {
+                "$type": "or",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "removable_media_devices"
+                    },
+                    {
+                        "$type": "primaryId",
+                        "value": "portable_devices"
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "0951"
+                            },
+                            {
+                                "$type": "productId",
+                                "value": "169D"
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "2009"
+                            },
+                            {
+                                "$type": "productId",
+                                "value": "16AF"
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "1908"
+                            },
+                            {
+                                "$type": "productId",
+                                "value": "0226"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "id": "7f191817-c305-451d-812a-1c4b03ebcec8",
+            "name": "Group for authorized dictaphones",
+            "query": {
+                "$type": "or",
+                "clauses": [
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "07B4"
+                            },
+                            {
+                                "$type": "or",
+                                "clauses": [
+                                    {
+                                        "$type": "productId",
+                                        "value": "0232"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "0279"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "0244"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "0264"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "0236"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "0245"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "0911"
+                            },
+                            {
+                                "$type": "or",
+                                "clauses": [
+                                    {
+                                        "$type": "productId",
+                                        "value": "1F40"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "251C"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "1D54"
+                            },
+                            {
+                                "$type": "or",
+                                "clauses": [
+                                    {
+                                        "$type": "productId",
+                                        "value": "1072"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "1070"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "1080"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "054C"
+                            },
+                            {
+                                "$type": "productId",
+                                "value": "0B6F"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "id": "1653593b-5b92-47e6-975a-c43ffa9cd28d",
+            "name": "Group for authorized image devices",
+            "query": {
+                "$type": "or",
+                "clauses": [
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "046D"
+                            },
+                            {
+                                "$type": "or",
+                                "clauses": [
+                                    {
+                                        "$type": "productId",
+                                        "value": "0837"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "085B"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "0825"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "03F0"
+                            },
+                            {
+                                "$type": "or",
+                                "clauses": [
+                                    {
+                                        "$type": "productId",
+                                        "value": "5705"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "5D05"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "040A"
+                            },
+                            {
+                                "$type": "or",
+                                "clauses": [
+                                    {
+                                        "$type": "productId",
+                                        "value": "6030"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "601D"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "1083"
+                            },
+                            {
+                                "$type": "or",
+                                "clauses": [
+                                    {
+                                        "$type": "productId",
+                                        "value": "1646"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "1647"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "04CA"
+                            },
+                            {
+                                "$type": "or",
+                                "clauses": [
+                                    {
+                                        "$type": "productId",
+                                        "value": "7053"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "7054"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "04F2"
+                            },
+                            {
+                                "$type": "productId",
+                                "value": "B51C"
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "05C8"
+                            },
+                            {
+                                "$type": "or",
+                                "clauses": [
+                                    {
+                                        "$type": "productId",
+                                        "value": "0383"
+                                    },
+                                    {
+                                        "$type": "productId",
+                                        "value": "034B"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "0461"
+                            },
+                            {
+                                "$type": "productId",
+                                "value": "4DFE"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "id": "d2887bd4-a916-4011-a385-83c6b15df529",
+            "name": "Group for authorized immo devices",
+            "query": {
+                "$type": "or",
+                "clauses": [
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "09CB"
+                            },
+                            {
+                                "$type": "productId",
+                                "value": "1007"
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "and",
+                        "clauses": [
+                            {
+                                "$type": "vendorId",
+                                "value": "0F7E"
+                            },
+                            {
+                                "$type": "productId",
+                                "value": "900C"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Removable Storage Access Control Samples/macOS/policy/examples/rules/audit_write_access.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/rules/audit_write_access.json
@@ -1,0 +1,26 @@
+{
+    "rules": [
+        {
+            "id": "f745aeec-3233-4ca5-961c-2e8b55510784",
+            "name": "Audit Write to all removable storage",
+            "includeGroups": [
+                "9b28fae8-72f7-4267-a1a5-685f747a7146"
+            ],
+            "excludeGroups": [],
+            "entries": [
+                {
+                    "$type": "removableMedia",
+                    "enforcement": {
+                        "$type": "auditAllow",
+                        "options": [
+                            "send_event"
+                        ]
+                    },
+                    "access": [
+                        "write"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Removable Storage Access Control Samples/macOS/policy/examples/rules/demo_policies.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/rules/demo_policies.json
@@ -1,0 +1,58 @@
+{
+    "rules": [
+        {
+            "id": "f7e75634-7eec-4e67-bec5-5e7750cb9e02",
+            "name": "Allow Read Activity",
+            "includeGroups": [
+                "9b28fae8-72f7-4267-a1a5-685f747a7146"
+            ],
+            "excludeGroups": [],
+            "entries": [
+                {
+                    "$type": "generic",
+                    "enforcement": {
+                        "$type": "allow"
+                    },
+                    "access": [
+                        "generic_read"
+                    ]
+                },
+                {
+                    "$type": "generic",
+                    "enforcement": {
+                        "$type": "auditAllow",
+                        "options": [
+                            "send_event"
+                        ]
+                    },
+                    "access": [
+                        "generic_read"
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "f3520ea7-fd1b-4237-8ebc-96911db44f8e",
+            "name": "Default Deny",
+            "includeGroups": [],
+            "excludeGroups": [],
+            "entries": [
+                {
+                    "$type": "generic",
+                    "enforcement": {
+                        "$type": "auditDeny",
+                        "options": [
+                            "send_event",
+                            "show_notification"
+                        ]
+                    },
+                    "access": [
+                        "generic_read",
+                        "generic_write",
+                        "generic_execute"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Removable Storage Access Control Samples/macOS/policy/examples/rules/scenario_1_gpo_policy_-_prevent_write_and_execute_access_to_all_but_allow_specific_approved_usbs.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/rules/scenario_1_gpo_policy_-_prevent_write_and_execute_access_to_all_but_allow_specific_approved_usbs.json
@@ -1,0 +1,73 @@
+{
+    "rules": [
+        {
+            "id": "36ae1037-a639-4cff-946b-b36c53089a4c",
+            "name": "Audit Write and Execute access to aproved USBs",
+            "includeGroups": [
+                "65fa649a-a111-4912-9294-fb6337a25038"
+            ],
+            "excludeGroups": [],
+            "entries": [
+                {
+                    "$type": "removableMedia",
+                    "enforcement": {
+                        "$type": "allow"
+                    },
+                    "access": [
+                        "write",
+                        "execute"
+                    ]
+                },
+                {
+                    "$type": "removableMedia",
+                    "enforcement": {
+                        "$type": "auditAllow",
+                        "options": [
+                            "send_event"
+                        ]
+                    },
+                    "access": [
+                        "write",
+                        "execute"
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "c544a991-5786-4402-949e-a032cb790d0e",
+            "name": "Block Write and Execute Access",
+            "includeGroups": [
+                "9b28fae8-72f7-4267-a1a5-685f747a7146"
+            ],
+            "excludeGroups": [
+                "65fa649a-a111-4912-9294-fb6337a25038"
+            ],
+            "entries": [
+                {
+                    "$type": "removableMedia",
+                    "enforcement": {
+                        "$type": "deny"
+                    },
+                    "access": [
+                        "write",
+                        "execute"
+                    ]
+                },
+                {
+                    "$type": "removableMedia",
+                    "enforcement": {
+                        "$type": "auditDeny",
+                        "options": [
+                            "send_event",
+                            "show_notification"
+                        ]
+                    },
+                    "access": [
+                        "write",
+                        "execute"
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
* Add macOS equivalents of existing Windows DC policy examples
  * macOS only supports a subset of the functionality of Windows
  * Only Windows policy/group files that have functional equivalence in macOS have been translated
* Add macOS specific examples.