### PR TITLE
[macOS] Add id field for entries in policy schema

### DIFF
--- a/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
+++ b/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
@@ -859,6 +859,14 @@
                         ]
                     }
                 },
+                "id": {
+                    "type": "string",
+                    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                    "title": "UUID of the entry",
+                    "examples": [
+                        "34aec8e5-e2fa-4d1e-8788-2b1284226653"
+                    ]
+                },
                 "__comments": {
                     "type": "string"
                 }
@@ -879,7 +887,8 @@
                         "backup_device",
                         "update_device",
                         "download_photos_from_device"
-                    ]
+                    ],
+                    "id": "34aec8e5-e2fa-4d1e-8788-2b1284226653"
                 }
             ]
         },
@@ -916,6 +925,14 @@
                             "read"
                         ]
                     }
+                },
+                "id": {
+                    "type": "string",
+                    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                    "title": "UUID of the entry",
+                    "examples": [
+                        "34aec8e5-e2fa-4d1e-8788-2b1284226653"
+                    ]
                 },
                 "__comments": {
                     "type": "string"
@@ -954,6 +971,14 @@
                             "send_files_to_device"
                         ]
                     }
+                },
+                "id": {
+                    "type": "string",
+                    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                    "title": "UUID of the entry",
+                    "examples": [
+                        "34aec8e5-e2fa-4d1e-8788-2b1284226653"
+                    ]
                 },
                 "__comments": {
                     "type": "string"
@@ -995,6 +1020,14 @@
                         ]
                     }
                 },
+                "id": {
+                    "type": "string",
+                    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                    "title": "UUID of the entry",
+                    "examples": [
+                        "34aec8e5-e2fa-4d1e-8788-2b1284226653"
+                    ]
+                },
                 "__comments": {
                     "type": "string"
                 }
@@ -1034,6 +1067,14 @@
                         ]
                     }
                 },
+                "id": {
+                    "type": "string",
+                    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                    "title": "UUID of the entry",
+                    "examples": [
+                        "34aec8e5-e2fa-4d1e-8788-2b1284226653"
+                    ]
+                },
                 "__comments": {
                     "type": "string"
                 }
@@ -1048,7 +1089,8 @@
                         "generic_read",
                         "generic_write",
                         "generic_execute"
-                    ]
+                    ],
+                    "id": "34aec8e5-e2fa-4d1e-8788-2b1284226653"
                 }
             ]
         }

--- a/Removable Storage Access Control Samples/macOS/policy/examples/audit_all_apple_devices.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/audit_all_apple_devices.json
@@ -24,6 +24,7 @@
             "entries": [
                 {
                     "$type": "appleDevice",
+                    "id": "2E75C9DE-5C96-40C1-8333-A52A9409DEB1",
                     "enforcement": {
                         "$type": "auditAllow",
                         "options": [

--- a/Removable Storage Access Control Samples/macOS/policy/examples/deny_all_bluetooth_devices_except_samsung.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/deny_all_bluetooth_devices_except_samsung.json
@@ -48,6 +48,7 @@
             "entries": [
                 {
                     "$type": "bluetoothDevice",
+                    "id": "803B32D7-639A-4A05-BFFB-E8998AA3304B",
                     "enforcement": {
                         "$type": "deny"
                     },
@@ -58,6 +59,7 @@
                 },
                 {
                     "$type": "bluetoothDevice",
+                    "id": "5AC7FBBF-5D96-4440-A5C2-87AB9055B45F",
                     "enforcement": {
                         "$type": "auditDeny",
                         "options": [
@@ -81,6 +83,7 @@
             "entries": [
                 {
                     "$type": "bluetoothDevice",
+                    "id": "477C626F-510E-4881-B475-592CF6E501AF",
                     "enforcement": {
                         "$type": "auditAllow",
                         "options": [

--- a/Removable Storage Access Control Samples/macOS/policy/examples/deny_debug_on_android.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/deny_debug_on_android.json
@@ -24,6 +24,7 @@
             "entries": [
                 {
                     "$type": "portableDevice",
+                    "id": "60D3AF56-A990-45D1-A67F-591B9E230E84",
                     "enforcement": {
                         "$type": "deny"
                     },
@@ -33,6 +34,7 @@
                 },
                 {
                     "$type": "portableDevice",
+                    "id": "3E611FD9-6CE0-4412-AA21-0FCC9F303BDE",
                     "enforcement": {
                         "$type": "auditDeny",
                         "options": [
@@ -46,6 +48,7 @@
                 },
                 {
                     "$type": "portableDevice",
+                    "id": "D23E59C8-B271-4500-8906-BDCEF9B31688",
                     "enforcement": {
                         "$type": "auditAllow",
                         "options": [

--- a/Removable Storage Access Control Samples/macOS/policy/examples/deny_removable_media_except_kingston.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/deny_removable_media_except_kingston.json
@@ -40,6 +40,7 @@
             "entries": [
                 {
                     "$type": "removableMedia",
+                    "id": "A7CEE2F8-CE34-4B34-9CFE-4133F0361035",
                     "enforcement": {
                         "$type": "deny"
                     },
@@ -51,6 +52,7 @@
                 },
                 {
                     "$type": "removableMedia",
+                    "id": "18BA3DD5-4C9A-458B-A756-F1499FE94FB4",
                     "enforcement": {
                         "$type": "auditDeny",
                         "options": [

--- a/Removable Storage Access Control Samples/macOS/policy/examples/rules/audit_write_access.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/rules/audit_write_access.json
@@ -10,6 +10,7 @@
             "entries": [
                 {
                     "$type": "removableMedia",
+                    "id": "ad2f69df-e6c5-4cd7-a2bf-bf7ef8c6c2b5",
                     "enforcement": {
                         "$type": "auditAllow",
                         "options": [

--- a/Removable Storage Access Control Samples/macOS/policy/examples/rules/demo_policies.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/rules/demo_policies.json
@@ -1,4 +1,5 @@
 {
+    "__comment": "Rule {b2061588-029e-427d-8404-6dfec096a571} is not translated as 'capture file information for write' is not currently supported on macOS.",
     "rules": [
         {
             "id": "f7e75634-7eec-4e67-bec5-5e7750cb9e02",
@@ -10,6 +11,7 @@
             "entries": [
                 {
                     "$type": "generic",
+                    "id": "27c79875-25d2-4765-aec2-cb2d1000613f",
                     "enforcement": {
                         "$type": "allow"
                     },
@@ -19,6 +21,7 @@
                 },
                 {
                     "$type": "generic",
+                    "id": "b280c2bf-ca5d-46a1-afc9-7e34d8098ca7",
                     "enforcement": {
                         "$type": "auditAllow",
                         "options": [
@@ -39,6 +42,7 @@
             "entries": [
                 {
                     "$type": "generic",
+                    "id": "6b9cf286-ec70-4463-bfaf-29f32bb5f0dc",
                     "enforcement": {
                         "$type": "auditDeny",
                         "options": [

--- a/Removable Storage Access Control Samples/macOS/policy/examples/rules/scenario_1_gpo_policy_-_prevent_write_and_execute_access_to_all_but_allow_specific_approved_usbs.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/rules/scenario_1_gpo_policy_-_prevent_write_and_execute_access_to_all_but_allow_specific_approved_usbs.json
@@ -10,6 +10,7 @@
             "entries": [
                 {
                     "$type": "removableMedia",
+                    "id": "a0bcff88-b8e4-4f48-92be-16c36adac930",
                     "enforcement": {
                         "$type": "allow"
                     },
@@ -20,6 +21,7 @@
                 },
                 {
                     "$type": "removableMedia",
+                    "id": "4a17df0b-d89d-430b-9cbe-8e0721192281",
                     "enforcement": {
                         "$type": "auditAllow",
                         "options": [
@@ -45,6 +47,7 @@
             "entries": [
                 {
                     "$type": "removableMedia",
+                    "id": "f8ddbbc5-8855-4776-a9f4-ee58c3a21414",
                     "enforcement": {
                         "$type": "deny"
                     },
@@ -55,6 +58,7 @@
                 },
                 {
                     "$type": "removableMedia",
+                    "id": "07e22eac-8b01-4778-a567-a8fa6ce18a0c",
                     "enforcement": {
                         "$type": "auditDeny",
                         "options": [


### PR DESCRIPTION
1. Add an 'id' field to individual entries for parity with the Windows policy format.  
2. Update example converted policy files to include the original entry's ID