### PR TITLE
[macOS] Add macOS v1 policy upgrade script

### DIFF
--- a/Removable Storage Access Control Samples/macOS/policy/README.md
+++ b/Removable Storage Access Control Samples/macOS/policy/README.md
@@ -42,3 +42,7 @@ The Device Control Policy schema is defined in [device_control_policy_schema.jso
 ## Examples
 
 The [examples](./examples/) directory contains a variety of example device control policies.
+
+## Scripts
+
+The [scripts](./scripts/) directory contains useful scripts for manipulating the policy JSON.

--- a/Removable Storage Access Control Samples/macOS/policy/examples/v1/deny_all_mount.plist
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/v1/deny_all_mount.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Block all removable storage devices -->
+<plist version="1.0">
+<dict>
+    <key>deviceControl</key>
+    <dict>
+        <key>navigationTarget</key>
+        <string>https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/mac-device-control-overview?view=o365-worldwide</string> 
+        <key>removableMediaPolicy</key>
+        <dict>
+            <key>enforcementLevel</key>
+            <string>block</string>
+            <!-- Default to block all devices -->
+            <key>permission</key>
+            <array>
+                <string>none</string>
+            </array>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/Removable Storage Access Control Samples/macOS/policy/examples/v1/mount_allowlist.plist
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/v1/mount_allowlist.plist
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Block all removable storage devices except specific devices defined by Vendor ID, Product ID, and Serial Number -->
+<plist version="1.0">
+<dict>
+    <key>deviceControl</key>
+    <dict>
+        <key>removableMediaPolicy</key>
+        <dict>
+            <key>enforcementLevel</key>
+            <string>block</string>
+            <!-- Default to block all devices -->
+            <key>permission</key>
+            <array>
+                <string>none</string>
+            </array>
+            <key>vendors</key>
+            <dict>
+                <key>0951</key>
+                <dict>
+                    <key>permission</key>
+                    <array>
+                        <string>none</string>
+                    </array>
+                    <key>products</key>
+                    <dict>
+                        <key>16AE</key>
+                        <dict>
+                            <key>permission</key>
+                            <array>
+                                <string>none</string>
+                            </array>
+                            <key>serialNumbers</key>
+                            <dict>
+                                <!-- Only devices that match VID, PID, and SN have RWX permissions -->
+                                <key>1C1B0D03D8C0E5B0A909025A</key>
+                                <array>
+                                    <string>read</string>
+                                    <string>write</string>
+                                    <string>execute</string>
+                                </array>
+                                <key>1C1B0D03D8C0E5B0A909025B</key>
+                                <array>
+                                    <string>read</string>
+                                    <string>write</string>
+                                    <string>execute</string>
+                                </array>
+                            </dict>
+                        </dict>
+                    </dict>
+                </dict>
+                <key>2537</key>
+                <dict>
+                    <key>permission</key>
+                    <array>
+                        <string>none</string>
+                    </array>
+                    <key>products</key>
+                    <dict>
+                        <key>1081</key>
+                        <dict>
+                            <key>permission</key>
+                            <array>
+                                <string>none</string>
+                            </array>
+                            <key>serialNumbers</key>
+                            <dict>
+                                <key>0123456789ABCDE</key>
+                                <array>
+                                    <string>read</string>
+                                    <string>write</string>
+                                    <string>execute</string>
+                                </array>
+                            </dict>
+                        </dict>
+                    </dict>
+                </dict>
+            </dict>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/Removable Storage Access Control Samples/macOS/policy/scripts/README.md
+++ b/Removable Storage Access Control Samples/macOS/policy/scripts/README.md
@@ -1,0 +1,11 @@
+# Scripts
+
+Useful scripts for interacting with Device Control for macOS policy JSON.
+
+## convert_dc_policy.py
+
+Used to convert Windows DC policy XML into equivalent macOS policy JSON.
+
+## upgrade_dc_policy.py
+
+Used to update v1 macOS DC policy plists into the new JSON policy format.

--- a/Removable Storage Access Control Samples/macOS/policy/scripts/convert_dc_policy.py
+++ b/Removable Storage Access Control Samples/macOS/policy/scripts/convert_dc_policy.py
@@ -408,12 +408,12 @@ if __name__ == '__main__':
 
     args = arg_parser.parse_args()
 
-    if args.groups_file is None and args.rules_file is None:
-        raise Exception('')
-
-    converted_policy = {}
-
     try:
+        if args.groups_file is None and args.rules_file is None:
+            raise Exception('At least --groups or --rules must be specified')
+
+        converted_policy = {}
+
         if args.groups_file is not None:
             converted_policy["groups"] = convert_groups(args.groups_file, args.strict)
 

--- a/Removable Storage Access Control Samples/macOS/policy/scripts/upgrade_dc_policy.py
+++ b/Removable Storage Access Control Samples/macOS/policy/scripts/upgrade_dc_policy.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+
+import uuid
+
+def log_error(text):
+    print("\033[0;31m" + text + "\033[00m")
+
+def log_warning(text):
+    print("\033[0;93m" + text + "\033[00m")
+
+def upgrade_settings(navigation_target):
+    upgraded_settings = {
+        "features": {
+            "removableMedia": {
+                "disable": False
+            }
+        }
+    }
+
+    if navigation_target is not None:
+        upgraded_settings['ux']= {
+            "navigationTarget": navigation_target
+        }
+
+    return upgraded_settings
+
+def convert_permissions(permissions):
+    access = ["read", "write", "execute"]
+
+    if "none" in permissions:
+        return access
+
+    for permission in permissions:
+        match permission:
+            case "read":
+                access.remove("read")
+            case "write":
+                access.remove("write")
+            case "execute":
+                access.remove("execute")
+            case _:
+                log_warning(f"Unsupported permission: [{permission}")
+
+    return access
+
+def add_deny_entries(rule, permissions):
+    access = convert_permissions(permissions)
+
+    if len(access) > 0:
+        # Deny everything we don't have permission for
+        deny_entry_id = str(uuid.uuid4())
+        deny_entry = {
+            "$type": "removableMedia",
+            "id": deny_entry_id,
+            "enforcement": {
+                "$type": "deny"
+            },
+            "access": access
+        }
+
+        # Make sure to send telemetry and show ux
+        audit_deny_entry_id = str(uuid.uuid4())
+        audit_deny_entry = {
+            "$type": "removableMedia",
+            "id": audit_deny_entry_id,
+            "enforcement": {
+                "$type": "auditDeny",
+                "options": [
+                    "send_event",
+                    "show_notification"
+                ]
+            },
+            "access": access
+        }
+
+        rule["entries"].append(deny_entry)
+        rule["entries"].append(audit_deny_entry)
+
+    if len(access) < 3:
+        # Allow everything that makes it past the deny entry
+        # Otherwise, this device may match another group/rule
+        allow_entry_id = str(uuid.uuid4())
+        allow_entry = {
+            "$type": "removableMedia",
+            "id": allow_entry_id,
+            "enforcement": {
+                "$type": "allow"
+            },
+            "access": [
+                "read",
+                "write",
+                "execute"
+            ]
+        }
+
+        rule["entries"].append(allow_entry)
+
+def add_allow_entries(rule, permissions):
+    access = convert_permissions(permissions)
+
+    # Allow all permissions, so that only this rule gets evaluated
+    allow_entry_id = str(uuid.uuid4())
+    allow_entry = {
+        "$type": "removableMedia",
+        "id": audit_allow_entry_id,
+        "enforcement": {
+            "$type": "allow"
+        },
+        "access": [
+            "read",
+            "write",
+            "execute"
+        ]
+    }
+
+    # Only send telemetry on items that would be blocked
+    audit_allow_entry_id = str(uuid.uuid4())
+    audit_allow_entry = {
+        "$type": "removableMedia",
+        "id": audit_allow_entry_id,
+        "enforcement": {
+            "$type": "auditAllow",
+            "options": [
+                "send_event"
+            ]
+        },
+        "access": access
+    }
+
+    rule["entries"].append(allow_entry)
+    rule["entries"].append(audit_allow_entry)
+
+def add_entries(rule, permissions, block):
+    if block:
+        add_deny_entries(rule, permissions)
+    else:
+        add_allow_entries(rule, permissions)
+
+def add_serial_number_rule(upgraded_policy, vendor_id, product_id, serial_numbers, block):
+    for serial_number in serial_numbers:
+        print('Adding rule for Serial Number: ' + serial_number)
+        permissions = serial_numbers[serial_number]
+
+        group_id = str(uuid.uuid4())
+        group = {
+            "id": group_id,
+            "name": "Removable Storage Devices: Vendor " + vendor_id + ", Product " + product_id + ", Serial Number " + serial_number,
+            "query": {
+                "$type": "and",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "removable_media_devices"
+                    },
+                    {
+                        "$type": "vendorId",
+                        "value": vendor_id
+                    },
+                    {
+                        "$type": "productId",
+                        "value": product_id
+                    },
+                    {
+                        "$type": "serialNumber",
+                        "value": serial_number
+                    }
+                ]
+            }
+        }
+
+        rule_id = str(uuid.uuid4())
+        rule = {
+            "id": rule_id,
+            "name": "Removable Storage Devices: Vendor " + vendor_id + ", Product " + product_id + ", Serial Number " + serial_number,
+            "includeGroups": [
+                group_id
+            ],
+            "entries": []
+        }
+
+        add_entries(rule, permissions, block)
+
+        upgraded_policy["groups"].append(group)
+        upgraded_policy["rules"].append(rule)
+
+
+def add_product_rules(upgraded_policy, vendor_id, products, block):
+    for product_id in products:
+        print('Adding rule for product: ' + product_id)
+        product = products[product_id]
+
+        group_id = str(uuid.uuid4())
+        group = {
+            "id": group_id,
+            "name": "Removable Storage Devices: Vendor " + vendor_id + ", Product " + product_id,
+            "query": {
+                "$type": "and",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "removable_media_devices"
+                    },
+                    {
+                        "$type": "vendorId",
+                        "value": vendor_id
+                    },
+                    {
+                        "$type": "productId",
+                        "value": product_id
+                    }
+                ]
+            }
+        }
+
+        rule_id = str(uuid.uuid4())
+        rule = {
+            "id": rule_id,
+            "name": "Removable Storage Devices: Vendor " + vendor_id + ", Product " + product_id,
+            "includeGroups": [
+                group_id
+            ],
+            "entries": []
+        }
+
+        permissions = product["permission"]
+
+        add_entries(rule, permissions, block)
+
+        upgraded_policy["groups"].append(group)
+        upgraded_policy["rules"].append(rule)
+
+        if 'serialNumbers' in product:
+            add_serial_number_rule(upgraded_policy, vendor_id, product_id, product['serialNumbers'], block)
+
+
+def add_vendor_rules(upgraded_policy, vendors, block):
+    for vendor_id in vendors:
+        print('Adding rule for vendor: ' + vendor_id)
+        vendor = vendors[vendor_id]
+
+        group_id = str(uuid.uuid4())
+        group = {
+            "id": group_id,
+            "name": "Removable Storage Devices: Vendor " + vendor_id,
+            "query": {
+                "$type": "and",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "removable_media_devices"
+                    },
+                    {
+                        "$type": "vendorId",
+                        "value": vendor_id
+                    }
+                ]
+            }
+        }
+
+        rule_id = str(uuid.uuid4())
+        rule = {
+            "id": rule_id,
+            "name": "Removable Storage Devices: Vendor " + vendor_id,
+            "includeGroups": [
+                group_id
+            ],
+            "entries": []
+        }
+
+        permissions = vendor["permission"]
+
+        add_entries(rule, permissions, block)
+
+        upgraded_policy["groups"].append(group)
+        upgraded_policy["rules"].append(rule)
+
+        if 'products' in vendor:
+            add_product_rules(upgraded_policy, vendor_id, vendor['products'], block)
+
+
+def add_global_rule(upgraded_policy, block, removable_media_policy):
+    print("Adding global rule")
+    group_id = str(uuid.uuid4())
+    group = {
+        "id": group_id,
+        "name": "Removable Storage Devices: All",
+        "query": {
+            "$type": "and",
+            "clauses": [
+                {
+                    "$type": "primaryId",
+                    "value": "removable_media_devices"
+                }
+            ]
+        }
+    }
+
+    rule_id = str(uuid.uuid4())
+    rule = {
+        "id": rule_id,
+        "name": "Removable Storage Devices: All",
+        "includeGroups": [
+            group_id
+        ],
+        "entries": []
+    }
+
+    permissions = removable_media_policy["permission"]
+
+    add_entries(rule, permissions, block)
+
+    upgraded_policy['groups'].append(group)
+    upgraded_policy['rules'].append(rule)
+
+    if 'vendors' in removable_media_policy:
+        add_vendor_rules(upgraded_policy, removable_media_policy["vendors"], block)
+
+def upgrade_removable_media_policy(removable_media_policy):
+    upgraded_policy = {
+        "groups": [],
+        "rules": []
+    }
+
+    if 'enforcementLevel' not in removable_media_policy:
+        raise Exception("'removableMediaPolicy' does not contain an 'enforcementLevel' key")
+
+    block = removable_media_policy["enforcementLevel"] == "block"
+
+    if 'permission' not in removable_media_policy:
+        raise Exception("'removableMediaPolicy' does not contain a 'permission' key")
+
+    add_global_rule(upgraded_policy, block, removable_media_policy)
+
+    # Reverse the rules so they go from most specific to least specific
+    upgraded_policy["rules"].reverse()
+
+    return upgraded_policy
+
+
+def upgrade_v1_policy(v1_policy):
+    import plistlib 
+
+    policy = plistlib.load(v1_policy)
+
+    if 'deviceControl' not in policy:
+        raise Exception("Policy does not contain a 'deviceControl' key")
+        
+    device_control = policy['deviceControl']
+        
+    if 'removableMediaPolicy' not in device_control:
+        raise Exception("'deviceControl' key does not contain a 'removableMediaPolicy'")
+
+    removable_media_policy = device_control['removableMediaPolicy']
+    
+    upgraded_policy = upgrade_removable_media_policy(removable_media_policy)
+
+    upgraded_policy["settings"] = upgrade_settings(device_control.get('navigationTarget'))
+
+    return upgraded_policy
+
+
+
+if __name__ == '__main__':
+    import argparse
+    import json
+
+    arg_parser = argparse.ArgumentParser(
+        description='Upgrades an existing Device Control for macOS v1 policy into a Device Control for macOS v2 policy.')
+
+    arg_parser.add_argument(type=argparse.FileType('rb'), dest="v1_policy", help='The v1 policy plist')
+    arg_parser.add_argument('-o', '--output', type=argparse.FileType('w', encoding='UTF-8'), default='dc_policy.json', dest="output_file", help='Specify the output file.  Defaults to dc_policy.json.')
+
+    args = arg_parser.parse_args()
+
+    try:
+        upgraded_policy = upgrade_v1_policy(args.v1_policy)
+
+        args.output_file.write(json.dumps(upgraded_policy, indent=2))
+    except Exception as e:
+        log_error("Failed to convert policy:")
+        log_error(str(e))


### PR DESCRIPTION
Add a script to upgrade a v1 DC for macOS policy to the new format.  The tool uses a naive approach to convert every single node of a v1 policy into a single v2 group and rule.  The output policy can be further manually manipulated to coalesce the naive groups/rules to reduce the overall complexity and increase maintainability.