### PR TITLE
Mac DC Group: type --> $type

### DIFF
--- a/Removable Storage Access Control Samples/macOS/policy/examples/audit_all_apple_devices.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/audit_all_apple_devices.json
@@ -1,7 +1,7 @@
 {
     "groups": [
         {
-            "type": "device",
+            "$type": "device",
             "id": "3f082cd3-f701-4c21-9a6a-ed115c28e217",
             "name": "All Apple Devices",
             "query": {

--- a/Removable Storage Access Control Samples/macOS/policy/examples/deny_all_bluetooth_devices_except_samsung.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/deny_all_bluetooth_devices_except_samsung.json
@@ -1,7 +1,7 @@
 {
     "groups": [
         {
-            "type": "device",
+            "$type": "device",
             "id": "3f082cd3-f701-4c21-9a6a-ed115c28e417",
             "name": "All Bluetooth Devices",
             "query": {
@@ -15,7 +15,7 @@
             }
         },
         {
-            "type": "device",
+            "$type": "device",
             "id": "1A783D32-C6A3-4F5F-9D47-271B12130DFD",
             "name": "Samsung Galaxy S21",
             "query": {

--- a/Removable Storage Access Control Samples/macOS/policy/examples/deny_debug_on_android.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/deny_debug_on_android.json
@@ -1,7 +1,7 @@
 {
     "groups": [
         {
-            "type": "device",
+            "$type": "device",
             "id": "3f082cd3-f701-4c21-9a6a-ed115c28e41D",
             "name": "All Android Devices",
             "query": {

--- a/Removable Storage Access Control Samples/macOS/policy/examples/deny_removable_media_except_kingston.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/deny_removable_media_except_kingston.json
@@ -1,7 +1,7 @@
 {
     "groups": [
         {
-            "type": "device",
+            "$type": "device",
             "id": "3f082cd3-f701-4c21-9a6a-ed115c28e211",
             "name": "All Removable Media Devices",
             "query": {
@@ -15,7 +15,7 @@
             }
         },
         {
-            "type": "device",
+            "$type": "device",
             "id": "3f082cd3-f701-4c21-9a6a-ed115c28e212",
             "name": "Kingston Devices",
             "query": {

--- a/Removable Storage Access Control Samples/macOS/policy/examples/groups/any_removable_storage_and_portable_device_group.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/groups/any_removable_storage_and_portable_device_group.json
@@ -1,7 +1,7 @@
 {
     "groups": [
         {
-            "type": "device",
+            "$type": "device",
             "id": "9b28fae8-72f7-4267-a1a5-685f747a7146",
             "name": "Any Removable Storage and Portable Device",
             "query": {

--- a/Removable Storage Access Control Samples/macOS/policy/examples/groups/approved_usbs_group.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/groups/approved_usbs_group.json
@@ -1,7 +1,7 @@
 {
     "groups": [
         {
-            "type": "device",
+            "$type": "device",
             "id": "65fa649a-a111-4912-9294-fb6337a25038",
             "name": "Approved USBs",
             "query": {

--- a/Removable Storage Access Control Samples/macOS/policy/examples/groups/demo_groups.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/groups/demo_groups.json
@@ -1,7 +1,7 @@
 {
     "groups": [
         {
-            "type": "device",
+            "$type": "device",
             "id": "65fa649a-a111-4912-9294-fb6337a25038",
             "name": "Approved USBs",
             "query": {
@@ -23,6 +23,7 @@
             }
         },
         {
+            "$type": "device",
             "id": "9b28fae8-72f7-4267-a1a5-685f747a7146",
             "name": "Any Removable Storage and Portable Device",
             "query": {

--- a/Removable Storage Access Control Samples/macOS/policy/examples/groups/mass_storage_groups_gpo_2.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/groups/mass_storage_groups_gpo_2.json
@@ -1,7 +1,7 @@
 {
     "groups": [
         {
-            "type": "device",
+            "$type": "device",
             "id": "fb4ad01e-f41a-46c6-9ac1-268efa0ea083",
             "name": "Group for all mass storage devices groups",
             "query": {
@@ -58,6 +58,7 @@
             }
         },
         {
+            "$type": "device",
             "id": "7f191817-c305-451d-812a-1c4b03ebcec8",
             "name": "Group for authorized dictaphones",
             "query": {
@@ -166,6 +167,7 @@
             }
         },
         {
+            "$type": "device",
             "id": "1653593b-5b92-47e6-975a-c43ffa9cd28d",
             "name": "Group for authorized image devices",
             "query": {
@@ -337,6 +339,7 @@
             }
         },
         {
+            "$type": "device",
             "id": "d2887bd4-a916-4011-a385-83c6b15df529",
             "name": "Group for authorized immo devices",
             "query": {


### PR DESCRIPTION
Example policies were incorrectly using 'type' as the type field name and not '$type'.  This would cause validation to fail.