### PR TITLE
Mac DC: Remove references to subqueries

### DIFF
--- a/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
+++ b/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
@@ -556,19 +556,8 @@
                     "type": "object",
                     "title": "A query which describes the devices to include in this group",
                     "required": [
-                        "$type"
-                    ],
-                    "anyOf": [
-                        {
-                            "required": [
-                                "clauses"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "subqueries"
-                            ]
-                        }
+                        "$type",
+                        "clauses"
                     ],
                     "additionalProperties": false,
                     "properties": {
@@ -579,7 +568,7 @@
                                 "all",
                                 "and"
                             ],
-                            "title": "Describes how this query combines clauses and subqueries",
+                            "title": "Describes how this query combines clauses",
                             "examples": [
                                 "all",
                                 "any"
@@ -645,9 +634,7 @@
                                 {
                                     "$type": "serialNumber",
                                     "value": "ABCDEFGHIJKLMNOP"
-                                }
-                            ],
-                            "subqueries": [
+                                },
                                 {
                                     "$type": "all",
                                     "clauses": [
@@ -671,9 +658,7 @@
                                         {
                                             "$type": "productId",
                                             "value": "3333"
-                                        }
-                                    ],
-                                    "subqueries": [
+                                        },
                                         {
                                             "$type": "all",
                                             "clauses": [
@@ -719,7 +704,7 @@
                             "enum": [
                                 "not"
                             ],
-                            "title": "Describes how this query combines clauses and subqueries",
+                            "title": "Negates the result of the contained query",
                             "examples": [
                                 "not"
                             ]
@@ -1295,9 +1280,7 @@
                             {
                                 "$type": "serialNumber",
                                 "value": "ABCDEFGHIJKLMNOP"
-                            }
-                        ],
-                        "subqueries": [
+                            },
                             {
                                 "$type": "all",
                                 "clauses": [
@@ -1321,9 +1304,7 @@
                                     {
                                         "$type": "productId",
                                         "value": "3333"
-                                    }
-                                ],
-                                "subqueries": [
+                                    },
                                     {
                                         "$type": "all",
                                         "clauses": [


### PR DESCRIPTION
Remove references to subqueries from the DC schema.  Subqueries were rolled directly into clauses prior to Private Preview.