### PR TITLE
Tags should be strings

### DIFF
--- a/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
+++ b/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
@@ -1065,8 +1065,14 @@
                     }
                 },
                 "tag": {
-                    "type": "number",
-                    "title": "Custom tag to propogate to portal"
+                    "type": "string",
+                    "title": "Custom tag to propogate to portal [64 bit unsigned integer]",
+                    "pattern": "^[0-9]+$",
+                    "format": "uint64",
+                    "examples": [
+                        "42",
+                        "98765432100"
+                    ]
                 },
                 "__comments": {
                     "type": "string"
@@ -1097,8 +1103,14 @@
                     }
                 },
                 "tag": {
-                    "type": "number",
-                    "title": "Custom tag to propogate to portal"
+                    "type": "string",
+                    "title": "Custom tag to propogate to portal [64 bit unsigned integer]",
+                    "pattern": "^[0-9]+$",
+                    "format": "uint64",
+                    "examples": [
+                        "42",
+                        "98765432100"
+                    ]
                 },
                 "__comments": {
                     "type": "string"


### PR DESCRIPTION
Tags are internally represented as uint64_t.  The JSON deserialization code is agnostic of the underlying format being string vs. numeric.

Tags were originally added to the schema as numeric, but JSON doesn't support 64 bit numerics.  Consequently, update the schema to use a string representation to enable 64 bit tags.