### PR TITLE
Remove disable_audit_deny from allow entry options

### DIFF
--- a/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
+++ b/Removable Storage Access Control Samples/macOS/policy/device_control_policy_schema.json
@@ -1097,7 +1097,6 @@
                     "title": "Options to control the behavior of allow events",
                     "items": {
                         "enum": [
-                            "disable_audit_deny",
                             "disable_audit_allow"
                         ]
                     }


### PR DESCRIPTION
Remove the disable_audit_deny option from an allow entry.  This option does nothing on macOS.