### PR TITLE
Add some additional policy examples for apple devices and portable de…

### DIFF
--- a/Removable Storage Access Control Samples/macOS/policy/examples/audit_mobile_devices.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/audit_mobile_devices.json
@@ -1,0 +1,64 @@
+{
+    "groups": [
+        {
+            "$type": "device",
+            "id": "3778B4FD-A98B-4374-9EFE-859B98446E7D",
+            "name": "All Mobile Devices",
+            "query": {
+                "$type": "or",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "portable_devices"
+                    },
+                    {
+                        "$type": "primaryId",
+                        "value": "apple_devices"
+                    }
+                ]
+            }
+        }
+    ],
+    "rules": [
+        {
+            "id": "2275E5E3-44D4-429E-A8BF-F73B390CBF46",
+            "name": "Audit All Mobile Devices",
+            "includeGroups": [
+                "3778B4FD-A98B-4374-9EFE-859B98446E7D"
+            ],
+            "entries": [
+                {
+                    "$type": "generic",
+                    "id": "0B77527F-ED25-4136-93CC-F604E847DAC4",
+                    "enforcement": {
+                        "$type": "auditAllow",
+                        "options": [
+                            "send_event"
+                        ]
+                    },
+                    "access": [
+                        "generic_read",
+                        "generic_write",
+                        "generic_execute"
+                    ]
+                }
+            ]
+        }
+    ],
+    "settings": {
+        "features": {
+            "appleDevice": {
+                "disable": false
+            },
+            "portableDevice": {
+                "disable": false
+            }
+        },
+        "global": {
+            "defaultEnforcement": "allow"
+        },
+        "ux": {
+            "navigationTarget": "http://www.microsoft.com"
+        }
+    }
+}

--- a/Removable Storage Access Control Samples/macOS/policy/examples/deny_mobile_devices.json
+++ b/Removable Storage Access Control Samples/macOS/policy/examples/deny_mobile_devices.json
@@ -1,0 +1,134 @@
+{
+    "groups": [
+        {
+            "$type": "device",
+            "id": "0B2198B2-8E29-4AAB-AFC8-8B2CF827CDE9",
+            "name": "All Portable Devices",
+            "query": {
+                "$type": "and",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "portable_devices"
+                    }
+                ]
+            }
+        },
+        {
+            "$type": "device",
+            "id": "3D2A9EF0-E587-4B90-A60F-C9BD6F9D2BB4",
+            "name": "All Apple Devices",
+            "query": {
+                "$type": "and",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "apple_devices"
+                    }
+                ]
+            }
+        }
+    ],
+    "rules": [
+        {
+            "id": "350C4528-DE48-4E73-9298-0C9823CA1064",
+            "name": "Block All Portable Devices",
+            "includeGroups": [
+                "3778B4FD-A98B-4374-9EFE-859B98446E7D"
+            ],
+            "entries": [
+                {
+                    "$type": "portableDevice",
+                    "id": "E0DB2A03-CAF8-48C6-9FC0-EB6A834166CA",
+                    "enforcement": {
+                        "$type": "deny"
+                    },
+                    "__comments": "Customize Access Below",
+                    "access": [
+                        "download_files_from_device",
+                        "send_files_to_device",
+                        "download_photos_from_device",
+                        "debug"
+                    ]
+                },
+                {
+                    "$type": "portableDevice",
+                    "id": "E8112895-D818-4CBE-B4CA-EE9FFE351A4C",
+                    "enforcement": {
+                        "$type": "auditDeny",
+                        "options": [
+                            "send_event",
+                            "show_notification"
+                        ]
+                    },
+                    "__comments": "Customize Access Below",
+                    "access": [
+                        "download_files_from_device",
+                        "send_files_to_device",
+                        "download_photos_from_device",
+                        "debug"
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "D861EEB3-9201-45F4-AC63-F823D4957D59",
+            "name": "Block All Apple Devices",
+            "includeGroups": [
+                "3D2A9EF0-E587-4B90-A60F-C9BD6F9D2BB4"
+            ],
+            "entries": [
+                {
+                    "$type": "appleDevice",
+                    "id": "03420B37-4F71-4AF3-AAE8-82D16817A194",
+                    "enforcement": {
+                        "$type": "deny"
+                    },
+                    "__comments": "Customize Access Below",
+                    "access": [
+                        "download_files_from_device",
+                        "sync_content_to_device",
+                        "backup_device",
+                        "update_device",
+                        "download_photos_from_device"
+                    ]
+                },
+                {
+                    "$type": "appleDevice",
+                    "id": "8C66DF38-A4A2-4C98-B69C-BF5D13F32044",
+                    "enforcement": {
+                        "$type": "auditDeny",
+                        "options": [
+                            "send_event",
+                            "show_notification"
+                        ]
+                    },
+                    "__comments": "Customize Access Below",
+                    "access": [
+                        "download_files_from_device",
+                        "sync_content_to_device",
+                        "backup_device",
+                        "update_device",
+                        "download_photos_from_device"
+                    ]
+                }
+            ]
+        }
+    ],
+    "settings": {
+        "features": {
+            "appleDevice": {
+                "disable": false
+            },
+            "portableDevice": {
+                "disable": false
+            }
+        },
+        "global": {
+            "defaultEnforcement": "allow"
+        },
+        "ux": {
+            "navigationTarget": "http://www.microsoft.com"
+        }
+    }
+}


### PR DESCRIPTION
Add new example policies demonstrating:

* How to combine primaryId clauses in a single device group
* Leverage the generic entry type
* Include Apple and Android devices in a single policy