### PR TITLE
Fix XML namespace for WindowsDefender.adml

### DIFF
--- a/windows/WindowsDefender.adml
+++ b/windows/WindowsDefender.adml
@@ -1,4 +1,5 @@
-<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/Policysecurity intelligence">
+<?xml version="1.0" encoding="utf-8"?>
+<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://www.microsoft.com/GroupPolicy/PolicyDefinitions">
 <displayName>enter display name here</displayName>
 <description>enter description here</description>
 <resources>


### PR DESCRIPTION
ADML files must be under `http://www.microsoft.com/GroupPolicy/PolicyDefinitions` namespace. 


Fixes #60 